### PR TITLE
start horizontal muons

### DIFF
--- a/fcl/FeSim.fcl
+++ b/fcl/FeSim.fcl
@@ -14,3 +14,5 @@ services.ProditionsService.strawPhysics.gasGain : 13630.0
 services.ProditionsService.strawElectronics.nADCPresamples : 11
 services.ProditionsService.strawElectronics.nADCPackets : 2
 services.ProditionsService.strawElectronics.defaultAdcdVdI : 0.764e6
+
+outputs.outfile.fileName: "FeSim.art"

--- a/fcl/VstSim.fcl
+++ b/fcl/VstSim.fcl
@@ -67,7 +67,7 @@ outputs:  {
   outfile : {
     module_type   :   RootOutput
       SelectEvents : [ "p1" ]
-    fileName      :   "FeSim.art"
+      fileName      :   "VstSim.art"
   }
 
 }

--- a/fcl/hmuSim.fcl
+++ b/fcl/hmuSim.fcl
@@ -10,4 +10,6 @@ services.ProditionsService.strawElectronics.nADCPresamples : 11
 services.ProditionsService.strawElectronics.nADCPackets : 2
 services.ProditionsService.strawElectronics.defaultAdcdVdI : 0.764e6
 
+outputs.outfile.fileName: "hmuSim.art"
+
 

--- a/fcl/hmuSim.fcl
+++ b/fcl/hmuSim.fcl
@@ -1,0 +1,13 @@
+#
+# generate horizontal muons in front of plane 0
+#
+#include "TrackerMCTune/fcl/VstSim.fcl"
+
+physics.producers.generate.inputfile : "TrackerMCTune/fcl/hmuSim.txt"
+
+# make readout match VST
+services.ProditionsService.strawElectronics.nADCPresamples : 11
+services.ProditionsService.strawElectronics.nADCPackets : 2
+services.ProditionsService.strawElectronics.defaultAdcdVdI : 0.764e6
+
+

--- a/fcl/hmuSim.txt
+++ b/fcl/hmuSim.txt
@@ -1,0 +1,37 @@
+// a rough simulation of tracker VST horizontal plane cosmics
+
+// enable process
+bool particleGun.do = true;
+
+// Limits on cos(polar angle):
+double particleGun.czmin =  0.8;
+double particleGun.czmax =  1.0;
+
+// Limits on phi angle:
+// defaults to all phi
+//double particleGun.phimin = 4.974199;
+//double particleGun.phimax = 4.974201;
+
+// Time limits in ns, relative to protons on target.
+double particleGun.tmin  =  1000.0;
+double particleGun.tmax  =  1000.0;
+
+// position - just upstream of plane 0
+vector<double> particleGun.point = {-3904.0, 0.0, 8635.0};
+// cover the whole plane
+vector<double> particleGun.halfLength = { 700.0, 700.0, 0.1 };
+
+// Limits on momentum (MeV/c):
+double particleGun.pmin = 100;
+double particleGun.pmax = 1000;
+
+// Particle Id - muons
+int particleGun.id = 13;
+
+// Mean particle.
+double particleGun.mean =  -1;
+
+// Control of histograms.
+bool particleGun.doHistograms = false;
+
+bool particleGun.verbose = false;


### PR DESCRIPTION
Richie, please confirm whether 
defaultAdcdVdI : 0.764e6
should be part of horizontal cosmics sim